### PR TITLE
fix: update claude-code-router command syntax

### DIFF
--- a/ROUTER_SETUP.md
+++ b/ROUTER_SETUP.md
@@ -1,0 +1,64 @@
+# Claude Code Router Configuration
+
+## Installation Complete ✅
+
+Claude Code Router has been installed and configured for your project.
+
+## Configuration
+
+The router is configured with multiple AI models via OpenRouter for different tasks:
+
+- **default**: GPT-5 (standard requests)
+- **webSearch**: Gemini 2.5 Flash Lite (web searches)
+- **background**: GPT OSS 20B (background tasks)
+- **longContext**: Gemini 2.5 Pro (documents > 100k tokens)
+- **think**: Claude Opus 4.1 (complex reasoning)
+
+### Long Context Threshold
+
+Automatically switches to `longContext` model when input exceeds 100,000 tokens.
+
+## Setup API Key
+
+To use the router, add your OpenRouter API key to `.env`:
+
+```bash
+OPENROUTER_API_KEY="your-openrouter-api-key"
+```
+
+Get your API key at: https://openrouter.ai/keys
+
+## Usage
+
+1. **Start the router:**
+
+   ```bash
+   ./start-router.sh
+   ```
+
+2. **In Claude Code, switch models dynamically:**
+   ```
+   /model webSearch   # Switch to Gemini 2.5 Flash Lite
+   /model think       # Switch to Claude Opus 4.1
+   /model background  # Switch to GPT OSS 20B
+   /model longContext # Switch to Gemini 2.5 Pro
+   /model default     # Back to GPT-5
+   ```
+
+## Files Created
+
+- `claude-code-router.config.json` - Router configuration
+- `start-router.sh` - Startup script
+- `.env` - API keys (add your keys)
+
+## Next Steps
+
+1. Add your OpenRouter API key to `.env`
+2. Run `./start-router.sh` to start the router
+3. Use `/model <route>` in Claude Code to switch models
+
+## Troubleshooting
+
+- Ensure OPENROUTER_API_KEY is set in `.env`
+- Check router is running: `ps aux | grep claude-code-router`
+- View logs for debugging if needed

--- a/claude-code-router.config.json
+++ b/claude-code-router.config.json
@@ -1,0 +1,16 @@
+{
+  "Router": {
+    "default": "OpenRouter,openai/gpt-5",
+    "webSearch": "OpenRouter,google/gemini-2.5-flash-lite",
+    "background": "OpenRouter,google/openai/gpt-oss-20b",
+    "longContext": "OpenRouter,google/gemini-2.5-pro",
+    "think": "OpenRouter,anthropic/claude-opus-4.1",
+    "longContextThreshold": 100000
+  },
+  "Providers": {
+    "OpenRouter": {
+      "baseURL": "https://openrouter.ai/api/v1",
+      "apiKey": "${OPENROUTER_API_KEY}"
+    }
+  }
+}

--- a/start-router.sh
+++ b/start-router.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# Start Claude Code Router
+# This script starts the claude-code-router with the local configuration
+
+echo "Starting Claude Code Router..."
+echo "Configuration: ./claude-code-router.config.json"
+echo ""
+echo "Available routes (all via OpenRouter):"
+echo "  - default: GPT-5"
+echo "  - webSearch: Gemini 2.5 Flash Lite"
+echo "  - background: GPT OSS 20B"
+echo "  - longContext: Gemini 2.5 Pro (threshold: 100k tokens)"
+echo "  - think: Claude Opus 4.1"
+echo ""
+echo "Use /model <route> in Claude Code to switch models"
+echo ""
+
+# Export the config path
+export CLAUDE_CODE_ROUTER_CONFIG="./claude-code-router.config.json"
+
+# Start the router
+claude-code-router start --config ./claude-code-router.config.json


### PR DESCRIPTION
- Fix start-router.sh to use 'claude-code-router start --config' instead of 'claude-code-router --config'
- Add ANTHROPIC_BASE_URL and ANTHROPIC_API_KEY to .env for router integration

🤖 Generated with [Claude Code](https://claude.ai/code)